### PR TITLE
Fix missing youtube link

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 ## Links:
 * [Build Video](https://youtu.be/Fw4YdQWvs6I)
-* [SW Setup & Config Video]()
+* [SW Setup & Config Video](https://youtu.be/r6JIZEq3aTU)
 * [Config Tool](https://lbre.de/BREmote/struct.html)
 * [Serial Terminal](https://lbre.de/BREmote/sertest.html)
 * [Expo Tool](https://lbre.de/BREmote/expo.html)


### PR DESCRIPTION
I just noticed the youtube link was missing so I added it to the readme